### PR TITLE
Update UI such that markers are never truncated

### DIFF
--- a/src/main/resources/view/ApplicantListCard.fxml
+++ b/src/main/resources/view/ApplicantListCard.fxml
@@ -38,28 +38,28 @@
         <FlowPane fx:id="skills" HBox.hgrow="ALWAYS" />
       </HBox>
       <HBox>
-        <Label fx:id="phoneTitle" styleClass="cell_small_label_title" text="\$title">
+        <Label fx:id="phoneTitle" minWidth="-Infinity" styleClass="cell_small_label_title" text="\$title">
                <HBox.margin>
                   <Insets right="3.0" />
                </HBox.margin></Label>
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       </HBox>
       <HBox>
-        <Label fx:id="emailTitle" styleClass="cell_small_label_title" text="\$title">
+        <Label fx:id="emailTitle" minWidth="-Infinity" styleClass="cell_small_label_title" text="\$title">
                <HBox.margin>
                   <Insets right="3.0" />
                </HBox.margin></Label>
         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       </HBox>
       <HBox>
-        <Label fx:id="jobTitle" styleClass="cell_small_label_title" text="\$title">
+        <Label fx:id="jobTitle" minWidth="-Infinity" styleClass="cell_small_label_title" text="\$title">
                <HBox.margin>
                   <Insets right="3.0" />
                </HBox.margin></Label>
         <Label fx:id="job" styleClass="cell_small_label" text="\$job" />
       </HBox>
       <HBox>
-        <Label fx:id="roundTitle" styleClass="cell_small_label_title" text="\$title">
+        <Label fx:id="roundTitle" minWidth="-Infinity" styleClass="cell_small_label_title" text="\$title">
                <HBox.margin>
                   <Insets right="3.0" />
                </HBox.margin></Label>


### PR DESCRIPTION
- MinWidth set for each label, such that it is never truncated regardless of data length/ window size
- Fixes bug #207 and #208 
- Screenshot attached below:
![Screenshot 2022-04-03 at 9 14 23 PM](https://user-images.githubusercontent.com/77224261/161429902-d037197f-edc4-41e5-aefa-d298ba87b07c.png)

