### PR TITLE
Fix index bug for flag command

### DIFF
--- a/src/main/java/seedu/linkedout/commons/util/StringUtil.java
+++ b/src/main/java/seedu/linkedout/commons/util/StringUtil.java
@@ -65,4 +65,21 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Returns true if {@code s} represents a non-zero unsigned double
+     * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isNonZeroUnsignedDouble(String s) {
+        requireNonNull(s);
+        try {
+            Double value = Double.parseDouble(s);
+            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/linkedout/logic/parser/FlagCommandParser.java
+++ b/src/main/java/seedu/linkedout/logic/parser/FlagCommandParser.java
@@ -22,8 +22,9 @@ public class FlagCommandParser implements Parser<FlagCommand> {
             Index index = ParserUtil.parseIndex(args);
             return new FlagCommand(index);
         } catch (ParseException pe) {
+            StringBuilder sb = new StringBuilder(pe.getMessage()).append("\n");
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FlagCommand.MESSAGE_USAGE), pe);
+                    sb.append(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FlagCommand.MESSAGE_USAGE)).toString(), pe);
         }
     }
 }

--- a/src/main/java/seedu/linkedout/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/linkedout/logic/parser/ParserUtil.java
@@ -24,6 +24,7 @@ import seedu.linkedout.model.skill.Skill;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INDEX_LARGE = "Index is too large to be parsed.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -32,6 +33,9 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (Double.parseDouble(trimmedIndex) > Integer.MAX_VALUE) {
+            throw new ParseException(MESSAGE_INDEX_LARGE);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/linkedout/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/linkedout/logic/parser/ParserUtil.java
@@ -33,6 +33,9 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (!StringUtil.isNonZeroUnsignedDouble(trimmedIndex)) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
         if (Double.parseDouble(trimmedIndex) > Integer.MAX_VALUE) {
             throw new ParseException(MESSAGE_INDEX_LARGE);
         }


### PR DESCRIPTION
There was a bug where if the number provided in the input was too large, the wrong error message will be shown, particularly for commands that make use of indexes.

This problem was caused by bad error handling. If a ParseException is thrown by ParserUtil, flag command (and any of the other commands for that matter), will catch that exception and rethrow a generic exception.

Flag command now adds the underlying exception message from ParserUtil with the the generic error message.

Resolves #178 